### PR TITLE
Fix for MapSPAM dataset access, update to V2r2

### DIFF
--- a/02_agriculture_drought/AGRICULTURE_DROUGHT_Risk_Assessment.ipynb
+++ b/02_agriculture_drought/AGRICULTURE_DROUGHT_Risk_Assessment.ipynb
@@ -66,14 +66,13 @@
    },
    "outputs": [],
    "source": [
-    "import json\n",
+    "import io\n",
     "import os\n",
     "import re\n",
-    "import urllib\n",
     "import zipfile\n",
     "\n",
     "import pooch\n",
-    "import pyDataverse.api\n",
+    "import requests\n",
     "\n",
     "import pandas as pd\n",
     "import numpy as np\n",
@@ -174,15 +173,11 @@
    "source": [
     "#auxiliary function to load region GeoJson file.\n",
     "def load_nuts_json(json_path):\n",
-    "    # dependencies: json, urllib, geopandas, \n",
-    "    while True:\n",
-    "        uh = urllib.request.urlopen(json_path)\n",
-    "        data = uh.read()\n",
-    "        break  \n",
-    "    gdf = gpd.GeoDataFrame.from_features(json.loads(data)[\"features\"])\n",
-    "    gdf['Location'] = gdf['CNTR_CODE'] \n",
+    "    response = requests.get(json_path)\n",
+    "    response.raise_for_status()\n",
+    "    gdf = gpd.GeoDataFrame.from_features(response.json()[\"features\"])\n",
+    "    gdf['Location'] = gdf['CNTR_CODE']\n",
     "    gdf = gdf.set_index('Location')\n",
-    "    #gdf.to_crs(pyproj.CRS.from_epsg(4326), inplace=True)\n",
     "    return gdf\n",
     "\n",
     "# load nuts2 spatial data\n",
@@ -345,7 +340,11 @@
     "Data is available as global `.tif` rasters at 5 arc-min resolution for different combinations of human inputs and irrigation modes.\n",
     "In this assessment, we will use data for crops grown under 'high' human inputs and 'all' irrigation modes.\n",
     "46 files are downloaded for the 2020 dataset, one for each crop available on the MapSPAM repository.\n",
-    "The step-by-step download procedure is explained within the code below."
+    "\n",
+    ":::{note}\n",
+    "The MapSPAM data provider requests that an email and institution is provided before granting access to the files.\n",
+    "Please insert your information into the variables starting with `guestbook_` below or the download might fail.\n",
+    ":::"
    ]
   },
   {
@@ -358,28 +357,46 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "ID 11596408, Filename: Readme_SPAM2020V2r0.txt\n",
-      "ID 11596409, Filename: spam2020V2r0_global_harvested_area.csv.zip\n",
-      "ID 11596412, Filename: spam2020V2r0_global_harvested_area.geotiff.zip\n",
-      "ID 11596414, Filename: spam2020V2r0_global_physical_area.csv.zip\n",
-      "ID 11596411, Filename: spam2020V2r0_global_physical_area.geotiff.zip\n",
-      "ID 11596413, Filename: spam2020V2r0_global_production.csv.zip\n",
-      "ID 11596407, Filename: spam2020V2r0_global_production.geotiff.zip\n",
-      "ID 11596410, Filename: spam2020V2r0_global_yield.csv.zip\n",
-      "ID 11596406, Filename: spam2020V2r0_global_yield.geotiff.zip\n"
+      "agriculture_workflow/data/spam2020V2r2_global_production already exists, not downloading again\n"
      ]
     }
    ],
    "source": [
-    "# Set up the API to retrieve the SPAM dataset from Harvard Dataverse given the DOI \n",
-    "base_url = 'https://dataverse.harvard.edu/'\n",
-    "api = pyDataverse.api.NativeApi(base_url)\n",
+    "def retrieve_mapspam_production(data_dir):\n",
+    "    api_url = 'https://dataverse.harvard.edu/api/v1'\n",
     "\n",
-    "# Retrieve and display the list of available files for the SPAM dataset\n",
-    "dataset = api.get_dataset('doi:10.7910/DVN/SWPENT')\n",
-    "files_list = dataset.json()['data']['latestVersion']['files']\n",
-    "for file in files_list:\n",
-    "    print(\"ID {id}, Filename: {filename}\".format(**file[\"dataFile\"]))"
+    "    # Data access for MapSPAM requires a guestbook entry (guestbookId 380).\n",
+    "    # Enter the requested information:\n",
+    "    guestbook_email = ''\n",
+    "    guestbook_institution = ''\n",
+    "\n",
+    "    # MapSPAM https://doi.org/10.7910/DVN/SWPENT\n",
+    "    # File spam2020V2r2_global_production.geotiff.zip\n",
+    "    datafile_id = 13827043\n",
+    "    url = f'{api_url}/access/datafile/{datafile_id}'\n",
+    "\n",
+    "    if guestbook_email and guestbook_institution:\n",
+    "        response = requests.post(url, json={\n",
+    "            'guestbookResponse': {'email': guestbook_email, 'institution': guestbook_institution}\n",
+    "        })\n",
+    "        url = response.json()['data']['signedUrl']\n",
+    "\n",
+    "    with requests.get(url) as response:\n",
+    "        response.raise_for_status()\n",
+    "        # Extract the SPAM files, select the 'all' irrigation files only\n",
+    "        with zipfile.ZipFile(io.BytesIO(response.content)) as zObject:\n",
+    "            selected_files = [x for x in zObject.namelist() if '_A.tif' in x]\n",
+    "            zObject.extractall(path=data_dir, members=selected_files)\n",
+    "\n",
+    "\n",
+    "# Output folder name, must match structure in downloaded zip file\n",
+    "spam_folder = os.path.join(data_dir, 'spam2020V2r2_global_production')\n",
+    "\n",
+    "if not os.path.isdir(spam_folder):\n",
+    "    print(f'Downloading MapSPAM production data to {spam_folder}')\n",
+    "    retrieve_mapspam_production(data_dir)\n",
+    "else:\n",
+    "    print(f'{spam_folder} already exists, not downloading again')"
    ]
   },
   {
@@ -388,44 +405,9 @@
    "metadata": {},
    "source": [
     ":::{tip}\n",
-    "You might be interested in other files in the SPAM directory than the production ones used in this workflow. In the list above, you can find the ID code needed to download them.\n",
-    "In this workflow we are using the global production GeoTIFF file and associated download ID.\n",
+    "You might be interested in other files in the SPAM directory than the production ones used in this workflow.\n",
+    "Browse the full dataset contents on the Harvard Dataverse website: https://doi.org/10.7910/DVN/SWPENT\n",
     ":::"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "id": "85d2d915-e993-4573-86a3-c60d1777376b",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Specify path where the downloaded zip file will be saved\n",
-    "spam_path = os.path.join(data_dir, 'spam_prod_geotiff.zip')\n",
-    "\n",
-    "# Output folder name, must match structure in downloaded zip file\n",
-    "spam_folder = os.path.join(data_dir, 'spam2020V2r0_global_production')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "id": "47cdbb94-0ebf-4405-a01c-5e69f47fa7e0",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Download the dataset for crops production given the ID\n",
-    "download_id = '11596407'\n",
-    "\n",
-    "data_api = pyDataverse.api.DataAccessApi(base_url)\n",
-    "response = data_api.get_datafile(download_id, is_pid=False)\n",
-    "with open(spam_path, \"wb\") as f:\n",
-    "    f.write(response.content)\n",
-    "\n",
-    "# Extract the SPAM files, select the 'all' irrigation files only\n",
-    "with zipfile.ZipFile(spam_path, 'r') as zObject:\n",
-    "    selected_files = [x for x in zObject.namelist() if '_A.tif' in x]\n",
-    "    zObject.extractall(path=data_dir, members=selected_files)"
    ]
   },
   {
@@ -449,12 +431,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BANA, BARL, BEAN, CASS, CHIC, CITR, CNUT, COCO, COFF, COTT, COWP, GROU, LENT, MAIZ, MILL, OCER, OFIB, OILP, ONIO, OOIL, OPUL, ORTS, PIGE, PLNT, PMIL, POTA, RAPE, RCOF, REST, RICE, RUBB, SESA, SORG, SOYB, SUGB, SUGC, SUNF, SWPO, TEAS, TEMF, TOBA, TOMA, TROF, VEGE, WHEA, YAMS\n"
+      "YAMS, BEAN, TROF, CITR, COWP, SESA, CHIC, PMIL, BARL, COCO, WHEA, POTA, CNUT, LENT, ONIO, OOIL, RAPE, COFF, SOYB, RUBB, TEMF, OPUL, OILP, TOMA, SUNF, PIGE, GROU, COTT, ORTS, SUGB, PLNT, RCOF, RICE, MILL, OFIB, TEAS, CASS, TOBA, OCER, SWPO, MAIZ, BANA, SORG, SUGC, REST, VEGE\n"
      ]
     }
    ],
    "source": [
-    "print(\", \".join(f.split(\"_\")[-2] for f in selected_files))"
+    "print(\", \".join(f.split(\"_\")[-2] for f in os.listdir(spam_folder)))"
    ]
   },
   {
@@ -473,7 +455,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 143,
+   "execution_count": 11,
    "id": "746926b9",
    "metadata": {
     "tags": []
@@ -497,11 +479,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 12,
    "id": "4c6af41b",
    "metadata": {},
    "outputs": [],
    "source": [
+    "def sample_raster(path, coords):\n",
+    "    with rasterio.open(raster_path) as src:\n",
+    "        scales = np.asarray(src.scales)\n",
+    "        offsets = np.asarray(src.offsets)\n",
+    "        values = np.asarray([x * scales + offsets for x in src.sample(coords_11)])\n",
+    "        values[values == src.nodata] = np.nan\n",
+    "    return values\n",
+    "\n",
+    "\n",
     "# Extraction of studied crops production\n",
     "crops_spam = np.empty((*fields_shape, len(spam_list)), dtype=np.float64)\n",
     "for a, crop in enumerate(spam_list):\n",
@@ -509,8 +500,7 @@
     "        if crop in i:\n",
     "            raster_path = os.path.join(spam_folder, i)\n",
     "            break\n",
-    "    with rasterio.open(raster_path) as src:\n",
-    "        crops_spam[:,:,a] = np.reshape([x[0] for x in src.sample(coords_11)], fields_shape)\n",
+    "    crops_spam[:,:,a] = np.reshape(sample_raster(raster_path, coords_11), fields_shape)\n",
     "\n",
     "crops_spam[crops_spam < 0] = np.nan\n",
     "\n",
@@ -520,11 +510,8 @@
     "    if not i.endswith(\".tif\"):\n",
     "        continue\n",
     "    raster_path = os.path.join(spam_folder, i)\n",
-    "    with rasterio.open(raster_path) as src:\n",
-    "        values = [x[0] for x in src.sample(coords_11)]\n",
-    "\n",
     "    # Create a new column for each raster\n",
-    "    df_spam_all[i] = values\n",
+    "    df_spam_all[i] = sample_raster(raster_path, coords_11).ravel()\n",
     "\n",
     "df_spam_sum = df_spam_all.sum(axis=1)\n",
     "spam_sum = df_spam_sum.to_numpy(dtype='float64')\n",
@@ -824,7 +811,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "climaax",
    "language": "python",
    "name": "python3"
   },
@@ -838,7 +825,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.12"
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,

--- a/02_agriculture_drought/AGRICULTURE_DROUGHT_Risk_Assessment_non-staple.ipynb
+++ b/02_agriculture_drought/AGRICULTURE_DROUGHT_Risk_Assessment_non-staple.ipynb
@@ -49,13 +49,14 @@
    },
    "outputs": [],
    "source": [
+    "import io\n",
     "import os\n",
     "import zipfile\n",
     "\n",
     "import pooch\n",
-    "import pyDataverse.api\n",
     "import eurostat\n",
     "import gisco_geodata\n",
+    "import requests\n",
     "\n",
     "import pandas as pd\n",
     "import geopandas as gpd\n",
@@ -251,7 +252,11 @@
     "Data is available as global `.tif` rasters at 5 arc-min resolution for different combinations of human inputs and irrigation modes.\n",
     "In this assessment, we will use data for crops grown under 'high' human inputs and 'all' irrigation modes.\n",
     "46 files are downloaded for the 2020 dataset, one for each crop available on the MapSPAM repository.\n",
-    "The step-by-step download procedure is explained within the code below."
+    "\n",
+    ":::{note}\n",
+    "The MapSPAM data provider requests that an email and institution is provided before granting access to the files.\n",
+    "Please insert your information into the variables starting with `guestbook_` below or the download might fail.\n",
+    ":::"
    ]
   },
   {
@@ -264,28 +269,46 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "ID 11596408, Filename: Readme_SPAM2020V2r0.txt\n",
-      "ID 11596409, Filename: spam2020V2r0_global_harvested_area.csv.zip\n",
-      "ID 11596412, Filename: spam2020V2r0_global_harvested_area.geotiff.zip\n",
-      "ID 11596414, Filename: spam2020V2r0_global_physical_area.csv.zip\n",
-      "ID 11596411, Filename: spam2020V2r0_global_physical_area.geotiff.zip\n",
-      "ID 11596413, Filename: spam2020V2r0_global_production.csv.zip\n",
-      "ID 11596407, Filename: spam2020V2r0_global_production.geotiff.zip\n",
-      "ID 11596410, Filename: spam2020V2r0_global_yield.csv.zip\n",
-      "ID 11596406, Filename: spam2020V2r0_global_yield.geotiff.zip\n"
+      "agriculture_workflow/data/spam2020V2r2_global_production already exists, not downloading again\n"
      ]
     }
    ],
    "source": [
-    "# Set up the API to retrieve the SPAM dataset from Harvard Dataverse given the DOI \n",
-    "base_url = 'https://dataverse.harvard.edu/'\n",
-    "api = pyDataverse.api.NativeApi(base_url)\n",
+    "def retrieve_mapspam_production(data_dir):\n",
+    "    api_url = 'https://dataverse.harvard.edu/api/v1'\n",
     "\n",
-    "# Retrieve and display the list of available files for the SPAM dataset\n",
-    "dataset = api.get_dataset('doi:10.7910/DVN/SWPENT')\n",
-    "files_list = dataset.json()['data']['latestVersion']['files']\n",
-    "for file in files_list:\n",
-    "    print(\"ID {id}, Filename: {filename}\".format(**file[\"dataFile\"]))"
+    "    # Data access for MapSPAM requires a guestbook entry (guestbookId 380).\n",
+    "    # Enter the requested information:\n",
+    "    guestbook_email = ''\n",
+    "    guestbook_institution = ''\n",
+    "\n",
+    "    # MapSPAM https://doi.org/10.7910/DVN/SWPENT\n",
+    "    # File spam2020V2r2_global_production.geotiff.zip\n",
+    "    datafile_id = 13827043\n",
+    "    url = f'{api_url}/access/datafile/{datafile_id}'\n",
+    "\n",
+    "    if guestbook_email and guestbook_institution:\n",
+    "        response = requests.post(url, json={\n",
+    "            'guestbookResponse': {'email': guestbook_email, 'institution': guestbook_institution}\n",
+    "        })\n",
+    "        url = response.json()['data']['signedUrl']\n",
+    "\n",
+    "    with requests.get(url) as response:\n",
+    "        response.raise_for_status()\n",
+    "        # Extract the SPAM files, select the 'all' irrigation files only\n",
+    "        with zipfile.ZipFile(io.BytesIO(response.content)) as zObject:\n",
+    "            selected_files = [x for x in zObject.namelist() if '_A.tif' in x]\n",
+    "            zObject.extractall(path=data_dir, members=selected_files)\n",
+    "\n",
+    "\n",
+    "# Output folder name, must match structure in downloaded zip file\n",
+    "spam_folder = os.path.join(data_dir, 'spam2020V2r2_global_production')\n",
+    "\n",
+    "if not os.path.isdir(spam_folder):\n",
+    "    print(f'Downloading MapSPAM production data to {spam_folder}')\n",
+    "    retrieve_mapspam_production(data_dir)\n",
+    "else:\n",
+    "    print(f'{spam_folder} already exists, not downloading again')"
    ]
   },
   {
@@ -294,44 +317,9 @@
    "metadata": {},
    "source": [
     ":::{tip}\n",
-    "You might be interested in other files in the SPAM directory than the production ones used in this workflow. In the list above, you can find the ID code needed to download them.\n",
-    "In this workflow we are using the global production GeoTIFF file and associated download ID.\n",
+    "You might be interested in other files in the SPAM directory than the production ones used in this workflow.\n",
+    "Browse the full dataset contents on the Harvard Dataverse website: https://doi.org/10.7910/DVN/SWPENT\n",
     ":::"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "85d2d915-e993-4573-86a3-c60d1777376b",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Specify path where the downloaded zip file will be saved\n",
-    "spam_path = os.path.join(data_dir, 'spam_prod_geotiff.zip')\n",
-    "\n",
-    "# Output folder name, must match structure in downloaded zip file\n",
-    "spam_folder = os.path.join(data_dir, 'spam2020V2r0_global_production')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "id": "47cdbb94-0ebf-4405-a01c-5e69f47fa7e0",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Download the dataset for crops production given the ID\n",
-    "download_id = '11596407'\n",
-    "\n",
-    "data_api = pyDataverse.api.DataAccessApi(base_url)\n",
-    "response = data_api.get_datafile(download_id, is_pid=False)\n",
-    "with open(spam_path, \"wb\") as f:\n",
-    "    f.write(response.content)\n",
-    "\n",
-    "# Extract the SPAM files, select the 'all' irrigation files only\n",
-    "with zipfile.ZipFile(spam_path, 'r') as zObject:\n",
-    "    selected_files = [x for x in zObject.namelist() if '_A.tif' in x]\n",
-    "    zObject.extractall(path=data_dir, members=selected_files)"
    ]
   },
   {
@@ -354,12 +342,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BANA, BARL, BEAN, CASS, CHIC, CITR, CNUT, COCO, COFF, COTT, COWP, GROU, LENT, MAIZ, MILL, OCER, OFIB, OILP, ONIO, OOIL, OPUL, ORTS, PIGE, PLNT, PMIL, POTA, RAPE, RCOF, REST, RICE, RUBB, SESA, SORG, SOYB, SUGB, SUGC, SUNF, SWPO, TEAS, TEMF, TOBA, TOMA, TROF, VEGE, WHEA, YAMS\n"
+      "YAMS, BEAN, TROF, CITR, COWP, SESA, CHIC, PMIL, BARL, COCO, WHEA, POTA, CNUT, LENT, ONIO, OOIL, RAPE, COFF, SOYB, RUBB, TEMF, OPUL, OILP, TOMA, SUNF, PIGE, GROU, COTT, ORTS, SUGB, PLNT, RCOF, RICE, MILL, OFIB, TEAS, CASS, TOBA, OCER, SWPO, MAIZ, BANA, SORG, SUGC, REST, VEGE\n"
      ]
     }
    ],
    "source": [
-    "print(\", \".join(f.split(\"_\")[-2] for f in selected_files))"
+    "print(\", \".join(f.split(\"_\")[-2] for f in os.listdir(spam_folder)))"
    ]
   },
   {
@@ -382,6 +370,15 @@
     "# Codes for extraction of MapSPAM file\n",
     "spam_list = ['TEMF', 'CITR', 'VEGE']\n",
     "\n",
+    "\n",
+    "def sample_raster(path, coords):\n",
+    "    with rasterio.open(raster_path) as src:\n",
+    "        scales = np.asarray(src.scales)\n",
+    "        offsets = np.asarray(src.offsets)\n",
+    "        values = np.asarray([x * scales + offsets for x in src.sample(coords_11)])\n",
+    "        values[values == src.nodata] = np.nan\n",
+    "    return values\n",
+    "\n",
     "# Find file and extract data for the studied region\n",
     "spam_folder = os.path.join(data_dir, 'spam2020V2r0_global_production')\n",
     "crops_spam = hazard_df[[\"lat\", \"lon\"]].copy().set_index([\"lat\", \"lon\"])\n",
@@ -390,8 +387,7 @@
     "        if crop in i:\n",
     "            raster_path = os.path.join(spam_folder, i)\n",
     "            break\n",
-    "    with rasterio.open(raster_path) as src:\n",
-    "        crops_spam[crop] = [x[0] for x in src.sample(coords_11)]\n",
+    "    crops_spam[crop] = sample_raster(raster_path, coords_11).ravel()\n",
     "\n",
     "crops_spam[crops_spam < 0] = np.nan"
    ]
@@ -978,7 +974,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "climaax",
    "language": "python",
    "name": "python3"
   },
@@ -992,7 +988,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.12"
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,

--- a/environment.yml
+++ b/environment.yml
@@ -29,6 +29,7 @@ dependencies:
     - python-kaleido=0.2.1
     - python=3.12
     - rasterio=1.3.10
+    - requests=2.32.3
     - rioxarray=0.15.7
     - scipy=1.15.2
     - shapely=2.0.6


### PR DESCRIPTION
Replaces the pyDataverse-based downloader with a direct POST-request to get the data using requests.

- Users now have to provide information for the dataset guestbook.
- Dataset update to 2nd revision.

Closes #33.